### PR TITLE
Bundle and build with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "npx @11ty/eleventy & npx vite",
-    "build": "npx @11ty/eleventy & npx vite build"
+    "dev": "run-s eleventy:build vite:dev",
+    "build": "run-s eleventy:build vite:build",
+    "eleventy:dev": "npx @11ty/eleventy --serve",
+    "eleventy:build": "npx @11ty/eleventy",
+    "vite:dev": "npx vite",
+    "vite:build": "npx vite build"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +20,9 @@
     "@11ty/eleventy": "^3.1.1"
   },
   "devDependencies": {
+    "del-cli": "^6.0.0",
+    "delete-empty": "^3.0.0",
+    "npm-run-all": "^4.1.5",
     "vite": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,17 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "npx @11ty/eleventy & npx vite",
+    "build": "npx @11ty/eleventy & npx vite build"
   },
   "keywords": [],
   "author": "",
   "license": "UNLICENSED",
   "dependencies": {
     "@11ty/eleventy": "^3.1.1"
+  },
+  "devDependencies": {
+    "vite": "^7.0.2"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+export default defineConfig({
+    root: 'public',
+    build: {
+        outDir: '../dist',
+        emptyOutDir: true
+    }
+})


### PR DESCRIPTION
My initial install and configuration combining 11ty and vite worked locally but failed to build on vercel.

Looking at the logs during the vercel build, I realized that 11ty was building the `public/index.html` **after** vercel attempted to build `dist`. Vercel builds from the `public/index.html`, so I needed to ensure that 11ty built first.

I utilized [Snugug's guidance here](https://snugug.com/musings/eleventy-plus-vite/#add-npm-scripts) to update my `package.json` scripts to ensure 11ty and vite ran sequentially. After that, my development build was successful on vercel.