### PR TITLE
Ignore public dir except assets + ignore src/assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 
 # node modules
 node_modules/
+
+# everything in public except assets
+public/*
+!public/assets
+
+# src assets
+src/assets


### PR DESCRIPTION
Quality of life improvements for git:
- Ensuring full `public` dir does not get tracked or pushed, only `public/assets'
- Ensuring `src/assets` does not get tracked or pushed