### PR TITLE
Update css to only make window body scrollable, not entire window

### DIFF
--- a/src/styles/extra.css
+++ b/src/styles/extra.css
@@ -16,7 +16,10 @@ h1 {
 }
 .window {
     background: rgba(192, 192, 192, 0.67);
-    max-height: 70%;
+    max-height: 100vh;
+}
+.window-body {
+    max-height: 70vh;
     overflow-y: auto;
 }
 a {


### PR DESCRIPTION
When I [updated the content ](https://github.com/hadleyrose/webby/pull/10) of my website's index to include a welcome/about me blurb, the fixed window containing it became problematic on mobile.

My [initial code](https://github.com/hadleyrose/webby/pull/11) for making the window scrollable worked, but I realized this update made it possible to scroll past the titlebar of the window.

In this update, I ensured the window-body element became scrollable, instead of the window itself.